### PR TITLE
Add run() alias and edit() function

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(git push:*)",
       "Bash(gh pr create --title \"Upgrade test suite to mini.test\" --body \"$(cat <<''EOF''\n## Summary\n- Migrate from plenary busted to mini.test for modern Neovim plugin testing\n- Replace plenary.log dependency with self-contained logger module\n- Add comprehensive Lua concept documentation in code comments\n- Create minimal_init.lua for isolated test environment\n- Update Makefile with new test commands and documentation\n- Add .luacheckrc for proper Neovim/test globals configuration\n\n## Why mini.test?\n- Provides child Neovim process isolation for proper functional testing\n- More programmatic test style (vs DSL-like busted)\n- Better maintained and part of the popular mini.nvim ecosystem\n- Proper test isolation prevents state pollution between tests\n\n## Test plan\n- [x] All 9 tests pass with `make test`\n- [x] Luacheck passes with no warnings\n- [x] StyLua formatting applied\n\nResolves #1\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\")",
       "Bash(gh pr merge:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary
- Add `run(cmd, opts)` as convenience wrapper for `new_pane`
- Add `edit(file, opts)` to open files using `zellij action edit`
- Support line number jumping with `--line-number` flag

## New API

```lua
-- run() - convenience for running commands
Zellij.run('npm test')
Zellij.run('cargo build', { close_on_exit = true, name = 'Build' })

-- edit() - open files in new pane with $EDITOR
Zellij.edit('/path/to/file.lua')
Zellij.edit(vim.fn.expand('%:p'), { floating = true })
Zellij.edit('/path/to/file.lua', { line = 42 })  -- Jump to line
```

## Why These Provide Value
- `run()` is the most common operation from Neovim (tests, builds, linters)
- `edit()` leverages Neovim's file context for side-by-side editing

## Test plan
- [x] All 38 tests pass
- [x] run() with command tested
- [x] run() with options tested
- [x] edit() with file tested
- [x] edit() options (line, direction, cwd) tested

Resolves #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)