### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        neovim-version: ['stable', 'nightly']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim-version }}
+
+      - name: Run tests
+        run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install luacheck
+        run: sudo apt-get install -y luacheck
+
+      - name: Install stylua
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check lua/ tests/
+
+      - name: Run luacheck
+        run: luacheck lua/ tests/ --no-unused-args --no-max-line-length

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zellij.nvim
 
+[![Tests](https://github.com/dsaenztagarro/zellij.nvim/actions/workflows/tests.yml/badge.svg)](https://github.com/dsaenztagarro/zellij.nvim/actions/workflows/tests.yml)
+
 Neovim plugin for seamless integration with [Zellij](https://zellij.dev/) terminal multiplexer.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for continuous integration
- Add Tests badge to README for visibility into CI status

## Changes
- **`.github/workflows/tests.yml`**: New CI workflow with:
  - Test job running `make test` on Neovim stable and nightly
  - Lint job running luacheck and stylua checks
- **`README.md`**: Add Tests badge linking to the workflow

## Test plan
- [x] Workflow syntax is valid
- [ ] Tests pass on GitHub Actions (will verify after merge)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)